### PR TITLE
Add callback option for custom prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ require("nudge-two-hats").setup({
   -- Prompt configuration
   system_prompt = "Analyze this code change and provide varied, specific advice based on the actual diff content. Consider whether the programmer is focusing on refactoring, adding new features, fixing bugs, or improving tests.",
   purpose = "", -- Work purpose or objective (e.g., "code review", "refactoring", "feature development")
+  callback = "", -- Vim function name to append its return value to the prompt
   
   -- Default CBT (Cognitive Behavioral Therapy) settings
   default_cbt = {
@@ -68,6 +69,7 @@ require("nudge-two-hats").setup({
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"Writing Coach", "Editor", "Reviewer", "Content Specialist", "Clarity Expert"},
+      callback = "", -- Optional Vim function for markdown files
     },
     -- Other filetypes configured similarly
     
@@ -174,6 +176,10 @@ The plugin tracks changes by filetype, allowing for more accurate and relevant s
 ### Purpose Parameter
 
 The purpose parameter enhances AI suggestions by providing context about your current work objective. This helps the AI generate more relevant and helpful advice tailored to your specific task.
+
+### Callback
+
+You can specify a Vim function name via the `callback` option. When defined, the plugin calls this function and appends its return value to the prompt. If the function does not exist, an empty string is appended.
 
 ## Requirements
 

--- a/lua/nudge-two-hats/config.lua
+++ b/lua/nudge-two-hats/config.lua
@@ -1,6 +1,8 @@
 local config = {
   system_prompt = "Analyze this code change and provide varied, specific advice based on the actual diff content. Consider whether the programmer is focusing on refactoring, adding new features, fixing bugs, or improving tests. Your advice should be tailored to the specific changes you see in the diff and should vary in content and style each time.",
   purpose = "", -- Work purpose or objective (e.g., "code review", "refactoring", "feature development")
+  -- Vim function name to append custom text to the prompt
+  callback = "",
   
   translations = {
     en = {
@@ -39,10 +41,11 @@ local config = {
     markdown = {
       prompt = "Give advice about this writing, focusing on clarity and structure.",
       role = "Cognitive behavioral therapy specialist",
-      direction = "Guide towards clearer and more structured writing", 
+      direction = "Guide towards clearer and more structured writing",
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"Writing Coach", "Editor", "Reviewer", "Content Specialist", "Clarity Expert"},
+      callback = "",
     },
     text = {
       prompt = "Give advice about this writing, focusing on clarity and structure.",
@@ -51,6 +54,7 @@ local config = {
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"Writing Coach", "Editor", "Reviewer", "Content Specialist", "Clarity Expert"},
+      callback = "",
     },
     tex = {
       prompt = "Give advice about this LaTeX document, focusing on structure and formatting.",
@@ -59,6 +63,7 @@ local config = {
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"LaTeX Expert", "Document Formatter", "Structure Specialist", "Academic Advisor", "Technical Writer"},
+      callback = "",
     },
     rst = {
       prompt = "Give advice about this reStructuredText document, focusing on clarity and organization.",
@@ -67,6 +72,7 @@ local config = {
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"Documentation Expert", "Structure Advisor", "Clarity Coach", "Technical Writer", "Information Architect"},
+      callback = "",
     },
     org = {
       prompt = "Give advice about this Org document, focusing on organization and structure.",
@@ -75,6 +81,7 @@ local config = {
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"Organization Expert", "Structure Advisor", "Productivity Coach", "Planning Specialist", "Task Manager"},
+      callback = "",
     },
     
     lua = {
@@ -84,6 +91,7 @@ local config = {
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"Code Reviewer", "Refactoring Expert", "Clean Code Advocate", "Performance Optimizer", "Maintainability Advisor"},
+      callback = "",
     },
     python = {
       prompt = "Give advice about this Python code change, focusing on which hat (refactoring or feature) the programmer is wearing.",
@@ -92,6 +100,7 @@ local config = {
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"Python Expert", "Code Reviewer", "Clean Code Advocate", "Performance Optimizer", "Pythonic Style Guide"},
+      callback = "",
     },
     javascript = {
       prompt = "Give advice about this JavaScript code change, focusing on which hat (refactoring or feature) the programmer is wearing.",
@@ -100,6 +109,7 @@ local config = {
       emotion = "Empathetic and understanding",
       tone = "Supportive and encouraging but direct",
       hats = {"JavaScript Expert", "Frontend Advisor", "Code Quality Advocate", "Performance Guru", "Best Practices Guide"},
+      callback = "",
     },
   },
   

--- a/test/buffer_spec.lua
+++ b/test/buffer_spec.lua
@@ -7,6 +7,7 @@ describe('nudge-two-hats buffer', function()
   local config = {
     debug_mode = false,
     min_interval = 30,
+    callback = "",
     filetype_prompts = {
       lua = {
         role = "Luaプログラマー",
@@ -14,7 +15,8 @@ describe('nudge-two-hats buffer', function()
         emotion = "思慮深い",
         tone = "専門的",
         prompt = "Luaコードの改善点を具体的に教えてください",
-        hats = {"Luaエキスパート", "メンター"}
+        hats = {"Luaエキスパート", "メンター"},
+        callback = ""
       },
       javascript = "JavaScriptのコードレビューをお願いします",
       python = {
@@ -23,7 +25,8 @@ describe('nudge-two-hats buffer', function()
         emotion = "分析的",
         tone = "教育的",
         prompt = "このPythonコードをどう改善できますか？",
-        hats = {"Python達人", "コードレビュアー"}
+        hats = {"Python達人", "コードレビュアー"},
+        callback = ""
       }
     },
     default_cbt = {
@@ -99,6 +102,7 @@ describe('nudge-two-hats buffer', function()
       -- Do nothing in tests
     end
   end)
+
   
   after_each(function()
     -- Restore original functions
@@ -108,9 +112,55 @@ describe('nudge-two-hats buffer', function()
     vim.api.nvim_win_get_cursor = state.original_nvim_win_get_cursor
     vim.diff = state.original_diff
     vim.cmd = state.original_vim_cmd
-    
+
     -- Clean up test buffer
     pcall(vim.api.nvim_buf_delete, state.test_buf, {force = true})
+  end)
+
+  it('callbackが存在する場合プロンプトに含めること', function()
+    config.callback = 'TestCallback'
+    vim.fn.exists = function(name)
+      if name == '*TestCallback' then
+        return 1
+      end
+      return 0
+    end
+    vim.fn.TestCallback = function()
+      return 'CB'
+    end
+    buffer.update_config(config)
+    state.buf_filetypes[state.test_buf] = 'lua'
+    local prompt = buffer.get_prompt_for_buffer(state.test_buf, state)
+    assert.matches('CB', prompt)
+  end)
+
+  it('ファイルタイプ固有のcallbackが優先されること', function()
+    config.callback = ''
+    config.filetype_prompts.lua.callback = 'LuaCb'
+    vim.fn.exists = function(name)
+      if name == '*LuaCb' then
+        return 1
+      end
+      return 0
+    end
+    vim.fn.LuaCb = function()
+      return 'LUA_CB'
+    end
+    buffer.update_config(config)
+    state.buf_filetypes[state.test_buf] = 'lua'
+    local prompt = buffer.get_prompt_for_buffer(state.test_buf, state)
+    assert.matches('LUA_CB', prompt)
+  end)
+
+  it('存在しないcallbackは空文字を追加するだけ', function()
+    config.callback = 'NoFunc'
+    vim.fn.exists = function()
+      return 0
+    end
+    buffer.update_config(config)
+    state.buf_filetypes[state.test_buf] = 'javascript'
+    local prompt = buffer.get_prompt_for_buffer(state.test_buf, state)
+    assert.equals('JavaScriptのコードレビューをお願いします', prompt)
   end)
   
   it('バッファの差分を正しく検出すること', function()

--- a/test/buffer_spec.lua
+++ b/test/buffer_spec.lua
@@ -103,7 +103,6 @@ describe('nudge-two-hats buffer', function()
     end
   end)
 
-  
   after_each(function()
     -- Restore original functions
     vim.api.nvim_buf_get_lines = state.original_nvim_buf_get_lines
@@ -131,6 +130,7 @@ describe('nudge-two-hats buffer', function()
     buffer.update_config(config)
     state.buf_filetypes[state.test_buf] = 'lua'
     local prompt = buffer.get_prompt_for_buffer(state.test_buf, state)
+    print('Actual prompt:', prompt)
     assert.matches('CB', prompt)
   end)
 


### PR DESCRIPTION
## Summary
- allow config to specify a vim function `callback`
- support callback in filetype prompts
- append callback results to prompt in buffer logic
- document the callback option in README
- test callback behaviour

## Testing
- `busted` *(fails: `command not found`)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional configuration parameter to specify a Vim function as a callback, allowing dynamic content to be appended to AI advice prompts globally or per filetype.

- **Documentation**
  - Updated documentation to explain the new callback configuration option and its integration with prompt generation.

- **Tests**
  - Added tests to verify prompt behavior with various callback configurations and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->