### PR TITLE
Fix message length handling for Gemini API calls

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
-  "workspace.library": ["path/to/library/directory", "vim.env.VIMRUNTIME"],
+  "workspace.library": ["path/to/library/directory", "vim.env.VIMRUNTIME",
+        "${3rd}/luassert/library"],
   "runtime.version": "Lua 5.3",
   "hint.enable": false,
   "diagnostics": {

--- a/lua/nudge-two-hats/api.lua
+++ b/lua/nudge-two-hats/api.lua
@@ -630,18 +630,22 @@ local function get_gemini_advice(diff, callback, prompt, purpose, state)
                   advice_cache[to_remove] = nil
                 end
               end
+              local message_length = config.notify_message_length
+              if context_for == "virtual_text" then
+                message_length = config.virtual_text_message_length
+              end
               if config.length_type == "characters" then
-                if #advice > config.notify_message_length then
-                  advice = safe_truncate(advice, config.notify_message_length)
+                if #advice > message_length then
+                  advice = safe_truncate(advice, message_length)
                 end
               else
                 local words = {}
                 for word in advice:gmatch("%S+") do
                   table.insert(words, word)
                 end
-                if #words > config.notify_message_length then
+                if #words > message_length then
                   local truncated_words = {}
-                  for i = 1, config.notify_message_length do
+                  for i = 1, message_length do
                     table.insert(truncated_words, words[i])
                   end
                   advice = table.concat(truncated_words, " ")
@@ -698,18 +702,22 @@ local function get_gemini_advice(diff, callback, prompt, purpose, state)
                response.candidates[1].content and response.candidates[1].content.parts and
                response.candidates[1].content.parts[1] and response.candidates[1].content.parts[1].text then
               local advice = response.candidates[1].content.parts[1].text
+              local message_length = config.notify_message_length
+              if context_for == "virtual_text" then
+                message_length = config.virtual_text_message_length
+              end
               if config.length_type == "characters" then
-                if #advice > config.notify_message_length then
-                  advice = safe_truncate(advice, config.notify_message_length)
+                if #advice > message_length then
+                  advice = safe_truncate(advice, message_length)
                 end
               else
                 local words = {}
                 for word in advice:gmatch("%S+") do
                   table.insert(words, word)
                 end
-                if #words > config.notify_message_length then
+                if #words > message_length then
                   local truncated_words = {}
-                  for i = 1, config.notify_message_length do
+                  for i = 1, message_length do
                     table.insert(truncated_words, words[i])
                   end
                   advice = table.concat(truncated_words, " ")

--- a/lua/nudge-two-hats/init.lua
+++ b/lua/nudge-two-hats/init.lua
@@ -451,7 +451,7 @@ function M.setup(opts)
         end
         -- 仮想テキスト用のアドバイスを保存
         state.virtual_text.last_advice[buf] = virtual_text_advice
-      end)
+      end, prompt, config.purpose, state)
       
       if content then
         -- Update content for all filetypes
@@ -480,7 +480,7 @@ function M.setup(opts)
           print("[Nudge Two Hats Debug] バッファ内容を更新しました: " .. table.concat(callback_filetypes, ", "))
         end
       end
-    end, prompt, config.purpose)
+    end, prompt, config.purpose, state)
   end, {})
   vim.api.nvim_create_user_command("NudgeTwoHatsDebugNotify", function()
     local buf = vim.api.nvim_get_current_buf()
@@ -558,8 +558,8 @@ function M.setup(opts)
           print("[Nudge Two Hats Debug] デバッグモードの仮想テキスト処理の結果: " .. virtual_text_advice)
         end
         state.virtual_text.last_advice[buf] = virtual_text_advice
-      end, prompt, config.purpose)
-    end, prompt, config.purpose)
+      end, prompt, config.purpose, state)
+    end, prompt, config.purpose, state)
     if config.debug_mode then
       print("[Nudge Two Hats Debug] 通知処理の発火が完了しました")
     end

--- a/lua/nudge-two-hats/init.lua
+++ b/lua/nudge-two-hats/init.lua
@@ -413,7 +413,7 @@ function M.setup(opts)
       print(diff)
     end
     -- Get the appropriate prompt for this buffer's filetype
-    local prompt = buffer.get_prompt_for_buffer(buf, state)
+    local prompt = buffer.get_prompt_for_buffer(buf, state, "notification")
     if config.debug_mode then
       print("[Nudge Two Hats Debug] get_gemini_adviceを呼び出します")
     end
@@ -442,6 +442,7 @@ function M.setup(opts)
       
       -- 仮想テキスト用に別途Gemini APIを呼び出し
       state.context_for = "virtual_text"
+      local vt_prompt = buffer.get_prompt_for_buffer(buf, state, "virtual_text")
       api.get_gemini_advice(diff, function(virtual_text_advice)
         if config.debug_mode then
           print("[Nudge Two Hats Debug] 仮想テキスト用APIコールバック実行: " .. (virtual_text_advice or "アドバイスなし"))
@@ -451,7 +452,7 @@ function M.setup(opts)
         end
         -- 仮想テキスト用のアドバイスを保存
         state.virtual_text.last_advice[buf] = virtual_text_advice
-      end, prompt, config.purpose, state)
+      end, vt_prompt, config.purpose, state)
       
       if content then
         -- Update content for all filetypes
@@ -528,7 +529,7 @@ function M.setup(opts)
                               context_content)
     local current_filetype = filetypes[1]
     -- Get the appropriate prompt for this buffer's filetype
-    local prompt = buffer.get_prompt_for_buffer(buf, state)
+    local prompt = buffer.get_prompt_for_buffer(buf, state, "notification")
     if config.debug_mode then
       print("[Nudge Two Hats Debug] 強制的に通知処理を実行します")
       print("[Nudge Two Hats Debug] Filetype: " .. (current_filetype or "unknown"))
@@ -537,7 +538,7 @@ function M.setup(opts)
     state.last_api_call = 0
     -- 通知用にGemini APIを呼び出し
     state.context_for = "notification"
-    api.get_gemini_advice(diff, function(advice) 
+    api.get_gemini_advice(diff, function(advice)
       if config.debug_mode then
         print("[Nudge Two Hats Debug] 通知処理の結果: " .. advice)
       end
@@ -553,12 +554,13 @@ function M.setup(opts)
       
       -- 仮想テキスト用に別途Gemini APIを呼び出し
       state.context_for = "virtual_text"
+      local vt_prompt = buffer.get_prompt_for_buffer(buf, state, "virtual_text")
       api.get_gemini_advice(diff, function(virtual_text_advice)
         if config.debug_mode then
           print("[Nudge Two Hats Debug] デバッグモードの仮想テキスト処理の結果: " .. virtual_text_advice)
         end
         state.virtual_text.last_advice[buf] = virtual_text_advice
-      end, prompt, config.purpose, state)
+      end, vt_prompt, config.purpose, state)
     end, prompt, config.purpose, state)
     if config.debug_mode then
       print("[Nudge Two Hats Debug] 通知処理の発火が完了しました")

--- a/lua/nudge-two-hats/init.lua
+++ b/lua/nudge-two-hats/init.lua
@@ -451,8 +451,8 @@ function M.setup(opts)
           print("================================")
         end
         -- 仮想テキスト用のアドバイスを保存
-        state.virtual_text.last_advice[buf] = virtual_text_advice
-      end, vt_prompt, config.purpose, state)
+      state.virtual_text.last_advice[buf] = virtual_text_advice
+      end, state)
       
       if content then
         -- Update content for all filetypes
@@ -560,7 +560,7 @@ function M.setup(opts)
           print("[Nudge Two Hats Debug] デバッグモードの仮想テキスト処理の結果: " .. virtual_text_advice)
         end
         state.virtual_text.last_advice[buf] = virtual_text_advice
-      end, vt_prompt, config.purpose, state)
+      end, prompt, config.purpose, state)
     end, prompt, config.purpose, state)
     if config.debug_mode then
       print("[Nudge Two Hats Debug] 通知処理の発火が完了しました")

--- a/lua/nudge-two-hats/timer.lua
+++ b/lua/nudge-two-hats/timer.lua
@@ -266,7 +266,7 @@ function M.start_notification_timer(buf, event_name, state, stop_notification_ti
           print("================================")
         end
         state.virtual_text.last_advice[buf] = virtual_text_advice
-      end)
+      end, prompt, config.purpose, state)
       
       if content then
         -- Update content for all filetypes
@@ -295,7 +295,7 @@ function M.start_notification_timer(buf, event_name, state, stop_notification_ti
           print("[Nudge Two Hats Debug] バッファ内容を更新しました: " .. table.concat(callback_filetypes, ", "))
         end
       end
-    end, prompt, config.purpose)
+    end, prompt, config.purpose, state)
   end)
   
   return state.timers.notification[buf]

--- a/lua/nudge-two-hats/timer.lua
+++ b/lua/nudge-two-hats/timer.lua
@@ -225,7 +225,7 @@ function M.start_notification_timer(buf, event_name, state, stop_notification_ti
       print(diff)
     end
     -- Get the appropriate prompt for this buffer's filetype
-    local prompt = buffer.get_prompt_for_buffer(buf, state)
+    local prompt = buffer.get_prompt_for_buffer(buf, state, "notification")
     -- 通知用のコンテキストを設定
     state.context_for = "notification"
     if config.debug_mode then
@@ -258,6 +258,7 @@ function M.start_notification_timer(buf, event_name, state, stop_notification_ti
       if config.debug_mode then
         print("[Nudge Two Hats Debug] get_gemini_adviceを呼び出します (仮想テキスト用)")
       end
+      local vt_prompt = buffer.get_prompt_for_buffer(buf, state, "virtual_text")
       api.get_gemini_advice(diff, function(virtual_text_advice)
         if config.debug_mode then
           print("[Nudge Two Hats Debug] 仮想テキスト用APIコールバック実行: " .. (virtual_text_advice or "アドバイスなし"))
@@ -266,7 +267,7 @@ function M.start_notification_timer(buf, event_name, state, stop_notification_ti
           print("================================")
         end
         state.virtual_text.last_advice[buf] = virtual_text_advice
-      end, prompt, config.purpose, state)
+      end, vt_prompt, config.purpose, state)
       
       if content then
         -- Update content for all filetypes

--- a/lua/nudge-two-hats/timer.lua
+++ b/lua/nudge-two-hats/timer.lua
@@ -267,7 +267,7 @@ function M.start_notification_timer(buf, event_name, state, stop_notification_ti
           print("================================")
         end
         state.virtual_text.last_advice[buf] = virtual_text_advice
-      end, vt_prompt, config.purpose, state)
+      end, state)
       
       if content then
         -- Update content for all filetypes


### PR DESCRIPTION
## Summary
- ensure Gemini API results respect context-specific message length

## Testing
- `busted --version` *(fails: command not found)*
- `nvim --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*