### PR TITLE
Fix config reset on BufEnter/BufLeave

### DIFF
--- a/lua/nudge-two-hats/autocmd.lua
+++ b/lua/nudge-two-hats/autocmd.lua
@@ -1,11 +1,16 @@
 local M = {}
 
+local config = require("nudge-two-hats.config")
+
+function M.update_config(new_config)
+  config = new_config
+end
+
 -- バッファ監視用の自動コマンドを作成する関数
 -- @param buf number バッファID
 -- @param state table プラグインの状態を保持するテーブル
--- @param config table 設定情報
 -- @param plugin_functions table プラグイン関数（start_notification_timer, clear_virtual_text, start_virtual_text_timer）
-function M.create_autocmd(buf, state, config, plugin_functions)
+function M.create_autocmd(buf, state, plugin_functions)
   local augroup = vim.api.nvim_create_augroup("nudge-two-hats-" .. buf, {})
   local content = table.concat(vim.api.nvim_buf_get_lines(buf, 0, -1, false), "\n")
   local filetypes = {}
@@ -152,7 +157,7 @@ function M.clear_tempfiles(debug_mode)
 end
 
 -- BufLeave自動コマンドのコールバック関数
-function M.buf_leave_callback(config, state, plugin_functions)
+function M.buf_leave_callback(state, plugin_functions)
   local buf = vim.api.nvim_get_current_buf()
   -- Stop notification timer
   local notification_timer_id = plugin_functions.stop_notification_timer(buf)
@@ -181,7 +186,7 @@ function M.buf_leave_callback(config, state, plugin_functions)
 end
 
 -- BufEnter自動コマンドのコールバック関数
-function M.buf_enter_callback(config, state, plugin_functions)
+function M.buf_enter_callback(state, plugin_functions)
   local buf = vim.api.nvim_get_current_buf()
   -- プラグインが有効な場合のみupdatetimeを設定
   if state.enabled then
@@ -212,26 +217,31 @@ function M.buf_enter_callback(config, state, plugin_functions)
 end
 
 -- 自動コマンドを設定する関数
-function M.setup(config, state, plugin_functions)
+function M.setup(state, plugin_functions)
+  local group = vim.api.nvim_create_augroup("nudge-two-hats-autocmd", { clear = true })
+
   vim.api.nvim_create_autocmd("VimLeavePre", {
+    group = group,
     pattern = "*",
     callback = function()
       M.clear_tempfiles(config.debug_mode)
-    end
+    end,
   })
 
   vim.api.nvim_create_autocmd("BufLeave", {
+    group = group,
     pattern = "*",
     callback = function()
-      M.buf_leave_callback(config, state, plugin_functions)
-    end
+      M.buf_leave_callback(state, plugin_functions)
+    end,
   })
 
   vim.api.nvim_create_autocmd("BufEnter", {
+    group = group,
     pattern = "*",
     callback = function()
-      M.buf_enter_callback(config, state, plugin_functions)
-    end
+      M.buf_enter_callback(state, plugin_functions)
+    end,
   })
 end
 

--- a/lua/nudge-two-hats/init.lua
+++ b/lua/nudge-two-hats/init.lua
@@ -132,7 +132,7 @@ function M.setup(opts)
       local augroup_name = "nudge-two-hats-" .. buf
       pcall(vim.api.nvim_del_augroup_by_name, augroup_name)
       -- create_autocmd関数をautocmdモジュールから呼び出します
-      autocmd.create_autocmd(buf, state, config, {
+      autocmd.create_autocmd(buf, state, {
         start_notification_timer = M.start_notification_timer,
         clear_virtual_text = M.clear_virtual_text,
         start_virtual_text_timer = M.start_virtual_text_timer
@@ -240,7 +240,7 @@ function M.setup(opts)
     local augroup_name = "nudge-two-hats-" .. buf
     pcall(vim.api.nvim_del_augroup_by_name, augroup_name)
     -- create_autocmd関数をautocmdモジュールから呼び出します
-    autocmd.create_autocmd(buf, state, config, {
+    autocmd.create_autocmd(buf, state, {
       start_notification_timer = M.start_notification_timer,
       clear_virtual_text = M.clear_virtual_text,
       start_virtual_text_timer = M.start_virtual_text_timer
@@ -573,7 +573,8 @@ function M.setup(opts)
     stop_virtual_text_timer = M.stop_virtual_text_timer,
     start_virtual_text_timer = M.start_virtual_text_timer
   }
-  autocmd.setup(config, state, plugin_functions)
+  autocmd.update_config(config)
+  autocmd.setup(state, plugin_functions)
 end
 
 return M

--- a/test/autocmd_spec.lua
+++ b/test/autocmd_spec.lua
@@ -163,6 +163,7 @@ describe('nudge-two-hats autocmd', function()
     
     -- autocmdモジュールを読み込む
     autocmd = require('nudge-two-hats.autocmd')
+    autocmd.update_config(config)
     
     -- テスト用バッファの設定
     state.test_buf = 1
@@ -187,7 +188,7 @@ describe('nudge-two-hats autocmd', function()
   
   it('自動コマンドが正しく作成されること', function()
     -- create_autocmd関数のテスト
-    autocmd.create_autocmd(state.test_buf, state, config, plugin_functions)
+    autocmd.create_autocmd(state.test_buf, state, plugin_functions)
     
     -- 自動コマンドが作成されたことを確認
     assert.is_not_nil(state.last_callback)
@@ -224,7 +225,8 @@ describe('nudge-two-hats autocmd', function()
     
     -- setup関数が正常に実行されることを確認
     local success, error_msg = pcall(function()
-      autocmd.setup(config, test_state, plugin_functions)
+      autocmd.update_config(config)
+      autocmd.setup(test_state, plugin_functions)
     end)
     
     -- エラーが発生しないことを確認
@@ -233,7 +235,8 @@ describe('nudge-two-hats autocmd', function()
   
   it('setupが適切な自動コマンドを登録すること', function()
     -- 自動コマンド設定のテスト
-    autocmd.setup(config, state, plugin_functions)
+    autocmd.update_config(config)
+    autocmd.setup(state, plugin_functions)
     
     -- 少なくとも1つの自動コマンドが作成されたことを確認
     assert.is_not_nil(state.last_callback)
@@ -247,7 +250,8 @@ describe('nudge-two-hats autocmd', function()
       'clear_tempfiles',
       'buf_leave_callback',
       'buf_enter_callback',
-      'setup'
+      'setup',
+      'update_config'
     }
     
     -- 全ての必要な関数が公開されていることを確認


### PR DESCRIPTION
## Summary
- keep user configuration in autocmd callbacks
- update init.lua to refresh autocmd module config
- adjust tests for new API

## Testing
- `busted -v` *(fails: command not found)*