### PR TITLE
feat: カーソルアイドル検出によるタイマー停止機能

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,129 +2,138 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Project Overview
+## プロジェクト概要
 
-nudge-two-hats.vim is a Neovim plugin that provides AI-powered coding advice using Gemini API. It monitors code changes and offers contextual suggestions through notifications and virtual text, implementing "nudge theory" to guide developers toward better coding practices.
+nudge-two-hats.vim は、Gemini APIを使用してAI駆動のコーディングアドバイスを提供するNeovimプラグインです。コード変更を監視し、通知とバーチャルテキストを通じてコンテキストに応じた提案を提供し、開発者をより良いコーディングプラクティスへと導く「ナッジ理論」を実装しています。
 
-## Architecture
+## アーキテクチャ
 
-The plugin follows a modular architecture with clear separation of concerns:
+このプラグインは、関心の分離が明確なモジュラーアーキテクチャに従っています：
 
-### Core Components
+### コアコンポーネント
 
-- **`lua/nudge-two-hats/init.lua`**: Main entry point and plugin state management
-- **`lua/nudge-two-hats/config.lua`**: Configuration system with context-specific settings for notifications vs virtual text
-- **`lua/nudge-two-hats/api.lua`**: Gemini API integration and text processing utilities
-- **`lua/nudge-two-hats/buffer.lua`**: Buffer content tracking and diff generation
-- **`lua/nudge-two-hats/timer.lua`**: Timer management for both notification and virtual text contexts
-- **`lua/nudge-two-hats/virtual_text.lua`**: Virtual text display and management
-- **`lua/nudge-two-hats/autocmd.lua`**: Autocommand setup and event handling
-- **`lua/nudge-two-hats/prompt.lua`**: Dynamic prompt generation with persona system
-- **`lua/nudge-two-hats/message_variety.lua`**: Message variety and persona selection
+- **`lua/nudge-two-hats/init.lua`**: メインエントリポイントとプラグイン状態管理
+- **`lua/nudge-two-hats/config.lua`**: 通知とバーチャルテキストのコンテキスト固有の設定を持つ設定システム
+- **`lua/nudge-two-hats/api.lua`**: Gemini API統合とテキスト処理ユーティリティ
+- **`lua/nudge-two-hats/buffer.lua`**: バッファ内容の追跡と差分生成
+- **`lua/nudge-two-hats/timer.lua`**: 通知とバーチャルテキストコンテキストの両方のタイマー管理
+- **`lua/nudge-two-hats/virtual_text.lua`**: バーチャルテキストの表示と管理
+- **`lua/nudge-two-hats/autocmd.lua`**: 自動コマンドのセットアップとイベント処理
+- **`lua/nudge-two-hats/prompt.lua`**: ペルソナシステムを使用した動的プロンプト生成
+- **`lua/nudge-two-hats/message_variety.lua`**: メッセージの多様性とペルソナ選択
 
-### Key Architectural Patterns
+### 主要なアーキテクチャパターン
 
-1. **Dual Context System**: The plugin operates in two distinct contexts:
-   - **Notification context**: For prominent UI notifications with longer, actionable advice
-   - **Virtual text context**: For subtle, unobtrusive hints displayed inline
+1. **デュアルコンテキストシステム**: プラグインは2つの異なるコンテキストで動作します：
+   - **通知コンテキスト**: より長く、実行可能なアドバイスを含む目立つUI通知用
+   - **バーチャルテキストコンテキスト**: インラインで表示される控えめで邪魔にならないヒント用
 
-2. **Buffer-Specific Timer Management**: Each buffer maintains separate timers for notifications and virtual text, preventing cross-buffer interference and reducing unnecessary API calls.
+2. **バッファ固有のタイマー管理**: 各バッファは通知とバーチャルテキスト用に別々のタイマーを維持し、バッファ間の干渉を防ぎ、不要なAPI呼び出しを削減します。
 
-3. **Filetype-Specific Configuration**: Different prompts, personas, and behaviors can be configured per filetype within each context.
+3. **ファイルタイプ固有の設定**: 各コンテキスト内でファイルタイプごとに異なるプロンプト、ペルソナ、動作を設定できます。
 
-4. **State Management**: Centralized state object (`state`) tracks buffer content, timers, API call timestamps, and virtual text display status.
+4. **状態管理**: 中央集権的な状態オブジェクト（`state`）がバッファ内容、タイマー、API呼び出しタイムスタンプ、バーチャルテキスト表示状態を追跡します。
 
-5. **Modular Function Wrappers**: `init.lua` provides wrapper functions that delegate to specialized modules while maintaining proper state references.
+5. **モジュラー関数ラッパー**: `init.lua`は適切な状態参照を維持しながら、専門化されたモジュールに委譲するラッパー関数を提供します。
 
-## Development Commands
+## 開発コマンド
 
-### Testing
+### テスト
 ```bash
-# Run all tests using plenary test harness
+# plenary test harnessを使用してすべてのテストを実行
 nvim --headless -c "lua require('plenary.test_harness').test_directory('test/', {minimal_init = 'luarc.json'})" -c "qa"
 
-# Alternative: Run using busted framework
-busted test/
+# 特定のテストファイルを実行（推奨）
+nvim --headless -c "lua require('plenary.test_harness').test_directory('test/api_spec.lua')" -c "qa"
+nvim --headless -c "lua require('plenary.test_harness').test_directory('test/timer_spec.lua')" -c "qa"
+nvim --headless -c "lua require('plenary.test_harness').test_directory('test/buffer_spec.lua')" -c "qa"
+nvim --headless -c "lua require('plenary.test_harness').test_directory('test/autocmd_spec.lua')" -c "qa"
+nvim --headless -c "lua require('plenary.test_harness').test_directory('test/virtual_text_spec.lua')" -c "qa"
 
-# Run specific test file
+# 代替: bustedフレームワークを使用して実行（bustedがインストールされている場合）
+busted test/
 busted test/api_spec.lua
 busted test/timer_spec.lua
 ```
 
-### Linting
-The project uses `.luarc.json` for Lua Language Server configuration:
-- Globals: `vim` is defined as a global
-- Diagnostics: Hints are disabled
+### リンティング
+プロジェクトはLua Language Server設定のために`.luarc.json`を使用します：
+- グローバル: `vim`がグローバルとして定義されています
+- 診断: ヒントは無効化されています
 
-### Manual Testing
-Use the plugin's built-in commands:
+### 手動テスト
+プラグインの組み込みコマンドを使用：
 ```vim
-:NudgeTwoHatsStart [filetype1 filetype2 ...]  " Start monitoring (with optional filetypes)
-:NudgeTwoHatsToggle [filetype1 filetype2 ...] " Toggle plugin on/off
-:NudgeTwoHatsNow            " Trigger immediate advice generation
-:NudgeTwoHatsDebug          " View plugin state and active timers
-:NudgeTwoHatsDebugNotify    " Force notification with debug output
+:NudgeTwoHatsStart [filetype1 filetype2 ...]  " モニタリング開始（オプションでファイルタイプ指定）
+:NudgeTwoHatsToggle [filetype1 filetype2 ...] " プラグインのオン/オフ切り替え
+:NudgeTwoHatsNow            " 即座にアドバイス生成をトリガー
+:NudgeTwoHatsDebug          " プラグインの状態とアクティブなタイマーを表示
+:NudgeTwoHatsDebugNotify    " デバッグ出力付きで通知を強制実行
 ```
 
-### Environment Setup
-- Set `GEMINI_API_KEY` environment variable for API access
-- Neovim 0.7.0+ required
+### 環境セットアップ
+- APIアクセスのために`GEMINI_API_KEY`環境変数を設定
+- Neovim 0.7.0以上が必要
 
-## Key Implementation Details
+## 主要な実装詳細
 
-### Timer Architecture
-- **Notification timers**: Trigger API calls for prominent advice (default: 5 minutes)
-- **Virtual text timers**: Handle inline text display (default: 10 minutes)
-- Both timer types are buffer-specific and independently managed
+### タイマーアーキテクチャ
+- **通知タイマー**: 目立つアドバイスのためのAPI呼び出しをトリガー（デフォルト: 5分）
+- **バーチャルテキストタイマー**: インラインテキスト表示を処理（デフォルト: 10分）
+- 両方のタイマータイプはバッファ固有で独立して管理されます
+- **カーソルアイドル検出**: カーソルが30秒以上動かない場合、すべてのタイマーを一時停止してAPI使用料を節約
 
-### API Integration
-- Uses Gemini 2.5 Flash Preview model
-- Requires `GEMINI_API_KEY` environment variable
-- Supports rate limiting and caching to minimize API calls
-- Handles both Japanese and English content with automatic language detection
+### API統合
+- Gemini 2.5 Flash Previewモデルを使用
+- `GEMINI_API_KEY`環境変数が必要
+- API呼び出しを最小限に抑えるためのレート制限とキャッシングをサポート
+- 自動言語検出により日本語と英語の両方のコンテンツを処理
 
-### Configuration System
-The config structure separates global settings from context-specific ones:
+### 設定システム
+config構造はグローバル設定とコンテキスト固有の設定を分離します：
 ```lua
 {
-  -- Global settings
+  -- グローバル設定
   notify_interval_seconds = 300,
   virtual_text_interval_seconds = 600,
+  cursor_idle_threshold_seconds = 30,
   
-  -- Context-specific settings
-  notification = { /* notification-specific config */ },
-  virtual_text = { /* virtual text-specific config */ }
+  -- コンテキスト固有の設定
+  notification = { /* 通知固有の設定 */ },
+  virtual_text = { /* バーチャルテキスト固有の設定 */ }
 }
 ```
 
-### State Management
-The plugin maintains several critical state objects:
-- `buf_content_by_filetype`: Tracks content changes per buffer and filetype
-- `timers.notification` & `timers.virtual_text`: Active timer tracking
-- `virtual_text.extmarks`: Virtual text display management
-- `last_api_call_*`: API rate limiting timestamps
+### 状態管理
+プラグインはいくつかの重要な状態オブジェクトを維持します：
+- `buf_content_by_filetype`: バッファとファイルタイプごとのコンテンツ変更を追跡
+- `timers.notification` & `timers.virtual_text`: アクティブなタイマーの追跡
+- `timers.paused_notification` & `timers.paused_virtual_text`: 一時停止中のタイマーの追跡
+- `last_cursor_move_time`: バッファごとの最終カーソル移動時刻
+- `virtual_text.extmarks`: バーチャルテキスト表示管理
+- `last_api_call_*`: APIレート制限のタイムスタンプ
 
-## Development Guidelines
+## 開発ガイドライン
 
-### Adding New Features
-1. Identify which context (notification/virtual_text) the feature affects
-2. Update the relevant module in `lua/nudge-two-hats/`
-3. Add corresponding tests in `test/`
-4. Update configuration schema if needed
+### 新機能の追加
+1. 機能が影響するコンテキスト（notification/virtual_text）を特定
+2. `lua/nudge-two-hats/`内の関連モジュールを更新
+3. `test/`に対応するテストを追加
+4. 必要に応じて設定スキーマを更新
 
-### Debugging
-Enable debug mode in configuration to see detailed logging:
+### デバッグ
+詳細なログを表示するには、設定でデバッグモードを有効にします：
 ```lua
 require("nudge-two-hats").setup({
   debug_mode = true
 })
 ```
 
-### Testing Strategy
-The test suite uses busted with extensive mocking:
-- Mock `vim.*` APIs for isolated testing
-- Test UTF-8 text handling specifically
-- Verify API sanitization and language detection
-- Test timer and state management
+### テスト戦略
+テストスイートは広範なモッキングを使用してbustedを使用します：
+- 分離されたテストのために`vim.*` APIをモック
+- UTF-8テキスト処理を特にテスト
+- APIサニタイゼーションと言語検出を検証
+- タイマーと状態管理をテスト
 
-This plugin demonstrates advanced Neovim plugin architecture with careful attention to performance, user experience, and maintainability.
+このプラグインは、パフォーマンス、ユーザー体験、保守性に細心の注意を払った高度なNeovimプラグインアーキテクチャを示しています。

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ require("nudge-two-hats").setup({
   
   notify_interval_seconds = 300,     -- Default: 5 minutes (300 seconds) for notifications
   virtual_text_interval_seconds = 600, -- Default: 10 minutes (600 seconds) for virtual text
+  cursor_idle_threshold_seconds = 30, -- Default: 30 seconds. Stop timers when cursor is idle for this long
   
   gemini_model = "gemini-2.5-flash-preview-05-20", -- Specify the Gemini model
   api_endpoint = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent",
@@ -204,6 +205,13 @@ require("nudge-two-hats").setup({
 ### Buffer-Specific Timer Management
 
 The plugin uses buffer-specific timers to reduce API calls and improve performance. Timers are only active for the current buffer and are automatically stopped when switching between buffers. This prevents unnecessary API calls from inactive buffers.
+
+### Cursor Idle Detection
+
+To save API costs when you're away from the editor, the plugin automatically pauses all timers when the cursor hasn't moved for a specified time (`cursor_idle_threshold_seconds`, default: 30 seconds). Timers automatically resume when you move the cursor again. This feature prevents unnecessary API calls when:
+- The editor is in the background
+- You're away from your desk
+- You're reading code without making changes
 
 ### Virtual Text Display
 

--- a/lua/nudge-two-hats/autocmd.lua
+++ b/lua/nudge-two-hats/autocmd.lua
@@ -161,8 +161,13 @@ function M.create_autocmd(buf, state_override, plugin_functions_override)
         m_plugin_functions.resume_notification_timer(buf)
       end
 
+      -- Resume virtual text timer if it was paused due to cursor idle
+      if m_plugin_functions.resume_virtual_text_timer then
+        m_plugin_functions.resume_virtual_text_timer(buf)
+      end
+
       if m_config and m_config.debug_mode then
-        print(string.format("[Nudge Two Hats Debug Autocmd] CursorMoved in buf %d: Updated cursor time, cleared display flag, cleared text, restarted VT timer, resumed notification timer.", buf))
+        print(string.format("[Nudge Two Hats Debug Autocmd] CursorMoved in buf %d: Updated cursor time, cleared display flag, cleared text, restarted VT timer, resumed timers.", buf))
       end
     end
   })
@@ -190,8 +195,13 @@ function M.create_autocmd(buf, state_override, plugin_functions_override)
         m_plugin_functions.resume_notification_timer(buf)
       end
 
+      -- Resume virtual text timer if it was paused due to cursor idle
+      if m_plugin_functions.resume_virtual_text_timer then
+        m_plugin_functions.resume_virtual_text_timer(buf)
+      end
+
       if m_config and m_config.debug_mode then
-        print(string.format("[Nudge Two Hats Debug Autocmd] CursorMovedI in buf %d: Updated cursor time, cleared display flag, cleared text, restarted VT timer, resumed notification timer.", buf))
+        print(string.format("[Nudge Two Hats Debug Autocmd] CursorMovedI in buf %d: Updated cursor time, cleared display flag, cleared text, restarted VT timer, resumed timers.", buf))
       end
     end
   })

--- a/lua/nudge-two-hats/init.lua
+++ b/lua/nudge-two-hats/init.lua
@@ -92,7 +92,7 @@ end
 
 -- timer.luaからの関数を呼び出すラッパー関数（virtual textタイマーの再開）
 function M.resume_virtual_text_timer(buf)
-  return timer.resume_virtual_text_timer(buf, state, M.stop_virtual_text_timer)
+  return timer.resume_virtual_text_timer(buf, state, M.stop_virtual_text_timer, M.display_virtual_text)
 end
 
 -- virtual_textモジュールをインポート

--- a/lua/nudge-two-hats/init.lua
+++ b/lua/nudge-two-hats/init.lua
@@ -85,6 +85,16 @@ function M.resume_notification_timer(buf)
   return timer.resume_notification_timer(buf, state, M.stop_notification_timer)
 end
 
+-- timer.luaからの関数を呼び出すラッパー関数（virtual textタイマーの一時停止）
+function M.pause_virtual_text_timer(buf)
+  return timer.pause_virtual_text_timer(buf, state)
+end
+
+-- timer.luaからの関数を呼び出すラッパー関数（virtual textタイマーの再開）
+function M.resume_virtual_text_timer(buf)
+  return timer.resume_virtual_text_timer(buf, state, M.stop_virtual_text_timer)
+end
+
 -- virtual_textモジュールをインポート
 local virtual_text = require("nudge-two-hats.virtual_text")
 
@@ -279,12 +289,27 @@ function M.setup(opts)
     state.timers = state.timers or {}
     state.timers.virtual_text = state.timers.virtual_text or {}
     state.timers.notification = state.timers.notification or {}
+    state.timers.paused_notification = state.timers.paused_notification or {}
+    state.timers.paused_virtual_text = state.timers.paused_virtual_text or {}
+    
     for buf, filetypes in pairs(state.buf_filetypes) do
       if vim.api.nvim_buf_is_valid(buf) then
         local notification_timer_id = state.timers.notification[buf]
         local virtual_text_timer_id = state.timers.virtual_text[buf]
+        local paused_notification = state.timers.paused_notification[buf]
+        local paused_virtual_text = state.timers.paused_virtual_text[buf]
         local legacy_timer_id = state.virtual_text.timers and state.virtual_text.timers[buf]
         print(string.format("\nバッファ: %d, Filetype: %s", buf, filetypes))
+        
+        -- Check for cursor idle status
+        if state.last_cursor_move_time and state.last_cursor_move_time[buf] then
+          local idle_time = os.time() - state.last_cursor_move_time[buf]
+          print(string.format("  カーソルアイドル時間: %d秒", idle_time))
+          if idle_time >= config.cursor_idle_threshold_seconds then
+            print("  **カーソルアイドル状態**")
+          end
+        end
+        
         -- Check notification timer
         if notification_timer_id then
           active_notification_timers = active_notification_timers + 1
@@ -300,6 +325,8 @@ function M.setup(opts)
           end
           print(string.format("  通知タイマー: ID = %d, 残り時間: %s",
                              notification_timer_id, remaining))
+        elseif paused_notification then
+          print(string.format("  通知タイマー: **一時停止中** (ID = %d)", paused_notification))
         end
         -- Check virtual text timer
         if virtual_text_timer_id then
@@ -316,6 +343,8 @@ function M.setup(opts)
           end
           print(string.format("  Virtual Textタイマー: ID = %d, 残り時間: %s",
                              virtual_text_timer_id, remaining))
+        elseif paused_virtual_text then
+          print(string.format("  Virtual Textタイマー: **一時停止中** (ID = %d)", paused_virtual_text))
         end
         -- Check legacy timer (for backward compatibility)
         if legacy_timer_id then

--- a/lua/nudge-two-hats/timer.lua
+++ b/lua/nudge-two-hats/timer.lua
@@ -110,7 +110,7 @@ function M.pause_virtual_text_timer(buf, state)
 end
 
 -- Function to resume virtual text timer for a buffer
-function M.resume_virtual_text_timer(buf, state, stop_virtual_text_timer_func)
+function M.resume_virtual_text_timer(buf, state, stop_virtual_text_timer_func, display_virtual_text_func)
   if not state.timers or not state.timers.paused_virtual_text or not state.timers.paused_virtual_text[buf] then
     return
   end
@@ -123,7 +123,7 @@ function M.resume_virtual_text_timer(buf, state, stop_virtual_text_timer_func)
   state.last_cursor_move_time[buf] = os.time()
 
   -- Restart the virtual text timer
-  M.start_virtual_text_timer(buf, "resume", state, nil)
+  M.start_virtual_text_timer(buf, "resume", state, display_virtual_text_func)
 
   if config.debug_mode then
     print(string.format("[Nudge Two Hats Debug Timer] Resumed virtual text timer for buf %d", buf))

--- a/test/timer_spec.lua
+++ b/test/timer_spec.lua
@@ -275,6 +275,37 @@ describe('nudge-two-hats timer', function()
     assert.is_not_nil(state.last_cursor_move_time[state.test_buf])
   end)
   
+  it('should resume virtual text timer on cursor movement', function()
+    -- Mock config
+    local config = {
+      debug_mode = false,
+      virtual_text_interval_seconds = 10,
+      cursor_idle_threshold_seconds = 30
+    }
+    timer.update_config(config)
+    
+    -- Set up paused timer state
+    state.timers.paused_virtual_text = {
+      [state.test_buf] = 5678 -- Mock timer ID
+    }
+    
+    -- Resume timer
+    local stop_func = function(buf)
+      timer.stop_virtual_text_timer(buf, state)
+    end
+    
+    local display_func = function(buf, advice)
+      -- Mock display function
+    end
+    
+    timer.resume_virtual_text_timer(state.test_buf, state, stop_func, display_func)
+    
+    -- Verify timer was resumed
+    assert.is_nil(state.timers.paused_virtual_text[state.test_buf])
+    assert.is_not_nil(state.timers.virtual_text[state.test_buf])
+    assert.is_not_nil(state.last_cursor_move_time[state.test_buf])
+  end)
+  
   it('should pause virtual text timer on cursor idle', function()
     -- Mock config
     local config = {

--- a/test/timer_spec.lua
+++ b/test/timer_spec.lua
@@ -213,5 +213,128 @@ describe('nudge-two-hats timer', function()
     state.enabled = true
   end)
   
+  it('should pause notification timer on cursor idle', function()
+    -- Mock config with cursor idle threshold
+    local config = {
+      debug_mode = false,
+      notify_interval_seconds = 5,
+      cursor_idle_threshold_seconds = 30
+    }
+    timer.update_config(config)
+    
+    -- Set up last cursor move time to simulate idle
+    state.last_cursor_move_time = {
+      [state.test_buf] = os.time() - 31 -- 31 seconds ago
+    }
+    
+    -- Start notification timer
+    local stop_func = function(buf)
+      timer.stop_notification_timer(buf, state)
+    end
+    
+    timer.start_notification_timer(state.test_buf, "test_event", state, stop_func)
+    
+    -- Verify timer was started
+    assert.is_not_nil(state.timers.notification[state.test_buf])
+    
+    -- Simulate timer callback execution (which should detect idle and pause)
+    -- Since we can't easily trigger the actual timer callback in tests,
+    -- we'll test the pause function directly
+    timer.pause_notification_timer(state.test_buf, state)
+    
+    -- Verify timer was paused
+    assert.is_nil(state.timers.notification[state.test_buf])
+    assert.is_not_nil(state.timers.paused_notification)
+    assert.is_not_nil(state.timers.paused_notification[state.test_buf])
+  end)
+  
+  it('should resume notification timer on cursor movement', function()
+    -- Mock config
+    local config = {
+      debug_mode = false,
+      notify_interval_seconds = 5,
+      cursor_idle_threshold_seconds = 30
+    }
+    timer.update_config(config)
+    
+    -- Set up paused timer state
+    state.timers.paused_notification = {
+      [state.test_buf] = 1234 -- Mock timer ID
+    }
+    
+    -- Resume timer
+    local stop_func = function(buf)
+      timer.stop_notification_timer(buf, state)
+    end
+    
+    timer.resume_notification_timer(state.test_buf, state, stop_func)
+    
+    -- Verify timer was resumed
+    assert.is_nil(state.timers.paused_notification[state.test_buf])
+    assert.is_not_nil(state.timers.notification[state.test_buf])
+    assert.is_not_nil(state.last_cursor_move_time[state.test_buf])
+  end)
+  
+  it('should pause virtual text timer on cursor idle', function()
+    -- Mock config
+    local config = {
+      debug_mode = false,
+      virtual_text_interval_seconds = 10,
+      cursor_idle_threshold_seconds = 30
+    }
+    timer.update_config(config)
+    
+    -- Set up last cursor move time to simulate idle
+    state.last_cursor_move_time = {
+      [state.test_buf] = os.time() - 31 -- 31 seconds ago
+    }
+    
+    -- Start virtual text timer
+    local display_func = function(buf, advice)
+      -- Mock display function
+    end
+    
+    timer.start_virtual_text_timer(state.test_buf, "test_event", state, display_func)
+    
+    -- Verify timer was started
+    assert.is_not_nil(state.timers.virtual_text[state.test_buf])
+    
+    -- Pause timer
+    timer.pause_virtual_text_timer(state.test_buf, state)
+    
+    -- Verify timer was paused
+    assert.is_nil(state.timers.virtual_text[state.test_buf])
+    assert.is_not_nil(state.timers.paused_virtual_text)
+    assert.is_not_nil(state.timers.paused_virtual_text[state.test_buf])
+  end)
+  
+  it('should check cursor idle correctly', function()
+    -- Mock config
+    local config = {
+      cursor_idle_threshold_seconds = 30
+    }
+    timer.update_config(config)
+    
+    -- Test when cursor has been idle for more than threshold
+    state.last_cursor_move_time = {
+      [state.test_buf] = os.time() - 31 -- 31 seconds ago
+    }
+    
+    local is_idle = timer.check_cursor_idle(state.test_buf, state)
+    assert.is_true(is_idle)
+    
+    -- Test when cursor has moved recently
+    state.last_cursor_move_time[state.test_buf] = os.time() - 10 -- 10 seconds ago
+    
+    is_idle = timer.check_cursor_idle(state.test_buf, state)
+    assert.is_false(is_idle)
+    
+    -- Test when no cursor move time is recorded
+    state.last_cursor_move_time = nil
+    
+    is_idle = timer.check_cursor_idle(state.test_buf, state)
+    assert.is_false(is_idle)
+  end)
+  
   -- Add more timer tests as needed
 end)


### PR DESCRIPTION
## 概要

エディタからフォーカスが外れた際の不要なAPI利用料金を削減するため、カーソルが一定時間動かない場合にタイマーを自動的に一時停止する機能を実装しました。

## 変更内容

### 新機能
- `cursor_idle_threshold_seconds`設定項目を追加（デフォルト: 30秒）
- カーソルの最終移動時刻を`CursorMoved`/`CursorMovedI`イベントで追跡
- カーソルアイドル時に通知とvirtual textの両タイマーを一時停止
- カーソル移動時に自動的にタイマーを再開
- `:NudgeTwoHatsDebug`コマンドでタイマーの一時停止状態を表示

### 実装詳細
- `timer.lua`: `pause_notification_timer()`, `resume_notification_timer()`, `pause_virtual_text_timer()`, `resume_virtual_text_timer()`, `check_cursor_idle()`関数を追加
- `autocmd.lua`: カーソル移動イベントで最終移動時刻を更新し、一時停止中のタイマーを再開
- `init.lua`: 新しいタイマー関数のラッパーを追加、デバッグ表示を拡張

### テスト
- カーソルアイドル検出のユニットテストを追加
- タイマーの一時停止・再開機能のテストを追加
- 全てのテストが成功することを確認済み

### ドキュメント
- README.mdに新機能の説明を追加
- CLAUDE.mdを更新（日本語版）

## 動作確認

1. プラグインを有効化
2. 30秒間カーソルを動かさない
3. `:NudgeTwoHatsDebug`で「**一時停止中**」と表示されることを確認
4. カーソルを動かすとタイマーが自動的に再開

## 解決する問題

Fixes #33

以下の状況でのAPI利用料金を削減：
- エディタがバックグラウンドにある時
- ユーザーが離席している時
- コードを読んでいるだけで編集していない時

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automatic pausing of timers when the cursor is idle, with a configurable idle threshold to reduce unnecessary API calls.
  * Added a new configuration option to set the cursor idle threshold (default: 30 seconds).
  * Timers automatically resume when cursor movement is detected.

* **Documentation**
  * Updated documentation to describe the new cursor idle detection feature and configuration.
  * Added a full Japanese translation of the main documentation.

* **Tests**
  * Added unit tests to verify timer pause/resume behavior and cursor idle detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->